### PR TITLE
Add filter to modify the block attributes

### DIFF
--- a/src/Blocks/Block.php
+++ b/src/Blocks/Block.php
@@ -123,6 +123,15 @@ class Block implements ArrayAccess {
 
 	protected static function parse_attributes($data, $block_type) {
 		$attributes = $data['attrs'];
+
+		/**
+		 * Filters the block attributes.
+		 *
+		 * @param array $attributes Block attributes.
+		 * @param array $block      Block object.
+		 */
+		$attributes = apply_filters('graphql_gutenberg_block_attributes_fields', $attributes, $block_type);
+
 		if ($block_type === null) {
 			return [
 				'attributes' => $attributes


### PR DESCRIPTION
Hi @pristas-peter I'm adding this filter to be able to modify the block attributes.

I created an ACF Block that consists of a repeater of several fields including images. The problem I found is that the images returned the ID instead of the source URL. The same happens with the relationship fields.

Registering a custom GraphQL type and filtering it with `graphql_gutenberg_block_attributes_fields` was good enough for the attributes, but still the **blocksJSON** field returned the original format stored by ACF.

![CleanShot 2021-12-30 at 15 20 01](https://user-images.githubusercontent.com/11416255/147778203-308a05e6-1835-4e73-b664-85d316e18a66.png)

This filter allows me to adjust the content that I finally get in `blocksJSON` to parse my data.

Let me know if this makes sense or is there a better way to do it. Thanks

